### PR TITLE
[app] delete items from fs on sync

### DIFF
--- a/.github/workflows/nightlies.yml
+++ b/.github/workflows/nightlies.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           app-id: ${{ vars.FPF_BRANCH_UPDATER_APP_ID }}
           private-key: ${{ secrets.FPF_BRANCH_UPDATER_APP_PRIVKEY }}
-          repostiories: |
+          repositories: |
             build-logs
             securedrop-apt-test
       - name: Commit and push

--- a/app/pnpm-lock.yaml
+++ b/app/pnpm-lock.yaml
@@ -523,6 +523,12 @@ packages:
   '@emotion/unitless@0.7.5':
     resolution: {integrity: sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==}
 
+  '@esbuild/aix-ppc64@0.25.10':
+    resolution: {integrity: sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/aix-ppc64@0.25.5':
     resolution: {integrity: sha512-9o3TMmpmftaCMepOdA5k/yDw8SfInyzWWTjYTFCX3kPSDJMROQTb8jg+h9Cnwnmm1vOzvxN7gIfB5V2ewpjtGA==}
     engines: {node: '>=18'}
@@ -535,6 +541,12 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/android-arm64@0.25.10':
+    resolution: {integrity: sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
   '@esbuild/android-arm64@0.25.5':
     resolution: {integrity: sha512-VGzGhj4lJO+TVGV1v8ntCZWJktV7SGCs3Pn1GRWI1SBFtRALoomm8k5E9Pmwg3HOAal2VDc2F9+PM/rEY6oIDg==}
     engines: {node: '>=18'}
@@ -545,6 +557,12 @@ packages:
     resolution: {integrity: sha512-IDrddSmpSv51ftWslJMvl3Q2ZT98fUSL2/rlUXuVqRXHCs5EUF1/f+jbjF5+NG9UffUDMCiTyh8iec7u8RlTLg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.25.10':
+    resolution: {integrity: sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [android]
 
   '@esbuild/android-arm@0.25.5':
@@ -559,6 +577,12 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-x64@0.25.10':
+    resolution: {integrity: sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
   '@esbuild/android-x64@0.25.5':
     resolution: {integrity: sha512-D2GyJT1kjvO//drbRT3Hib9XPwQeWd9vZoBJn+bu/lVsOZ13cqNdDeqIF/xQ5/VmWvMduP6AmXvylO/PIc2isw==}
     engines: {node: '>=18'}
@@ -571,6 +595,12 @@ packages:
     cpu: [x64]
     os: [android]
 
+  '@esbuild/darwin-arm64@0.25.10':
+    resolution: {integrity: sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-arm64@0.25.5':
     resolution: {integrity: sha512-GtaBgammVvdF7aPIgH2jxMDdivezgFu6iKpmT+48+F8Hhg5J/sfnDieg0aeG/jfSvkYQU2/pceFPDKlqZzwnfQ==}
     engines: {node: '>=18'}
@@ -581,6 +611,12 @@ packages:
     resolution: {integrity: sha512-XIpIDMAjOELi/9PB30vEbVMs3GV1v2zkkPnuyRRURbhqjyzIINwj+nbQATh4H9GxUgH1kFsEyQMxwiLFKUS6Rg==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.25.10':
+    resolution: {integrity: sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [darwin]
 
   '@esbuild/darwin-x64@0.25.5':
@@ -595,6 +631,12 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@esbuild/freebsd-arm64@0.25.10':
+    resolution: {integrity: sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-arm64@0.25.5':
     resolution: {integrity: sha512-nk4tGP3JThz4La38Uy/gzyXtpkPW8zSAmoUhK9xKKXdBCzKODMc2adkB2+8om9BDYugz+uGV7sLmpTYzvmz6Sw==}
     engines: {node: '>=18'}
@@ -605,6 +647,12 @@ packages:
     resolution: {integrity: sha512-z93DmbnY6fX9+KdD4Ue/H6sYs+bhFQJNCPZsi4XWJoYblUqT06MQUdBCpcSfuiN72AbqeBFu5LVQTjfXDE2A6Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.25.10':
+    resolution: {integrity: sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [freebsd]
 
   '@esbuild/freebsd-x64@0.25.5':
@@ -619,6 +667,12 @@ packages:
     cpu: [x64]
     os: [freebsd]
 
+  '@esbuild/linux-arm64@0.25.10':
+    resolution: {integrity: sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm64@0.25.5':
     resolution: {integrity: sha512-Z9kfb1v6ZlGbWj8EJk9T6czVEjjq2ntSYLY2cw6pAZl4oKtfgQuS4HOq41M/BcoLPzrUbNd+R4BXFyH//nHxVg==}
     engines: {node: '>=18'}
@@ -629,6 +683,12 @@ packages:
     resolution: {integrity: sha512-BlB7bIcLT3G26urh5Dmse7fiLmLXnRlopw4s8DalgZ8ef79Jj4aUcYbk90g8iCa2467HX8SAIidbL7gsqXHdRw==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.25.10':
+    resolution: {integrity: sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==}
+    engines: {node: '>=18'}
+    cpu: [arm]
     os: [linux]
 
   '@esbuild/linux-arm@0.25.5':
@@ -643,6 +703,12 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.25.10':
+    resolution: {integrity: sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-ia32@0.25.5':
     resolution: {integrity: sha512-sQ7l00M8bSv36GLV95BVAdhJ2QsIbCuCjh/uYrWiMQSUuV+LpXwIqhgJDcvMTj+VsQmqAHL2yYaasENvJ7CDKA==}
     engines: {node: '>=18'}
@@ -653,6 +719,12 @@ packages:
     resolution: {integrity: sha512-e7S3MOJPZGp2QW6AK6+Ly81rC7oOSerQ+P8L0ta4FhVi+/j/v2yZzx5CqqDaWjtPFfYz21Vi1S0auHrap3Ma3A==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.25.10':
+    resolution: {integrity: sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
     os: [linux]
 
   '@esbuild/linux-loong64@0.25.5':
@@ -667,6 +739,12 @@ packages:
     cpu: [loong64]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.25.10':
+    resolution: {integrity: sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-mips64el@0.25.5':
     resolution: {integrity: sha512-kB/66P1OsHO5zLz0i6X0RxlQ+3cu0mkxS3TKFvkb5lin6uwZ/ttOkP3Z8lfR9mJOBk14ZwZ9182SIIWFGNmqmg==}
     engines: {node: '>=18'}
@@ -677,6 +755,12 @@ packages:
     resolution: {integrity: sha512-YcM5br0mVyZw2jcQeLIkhWtKPeVfAerES5PvOzaDxVtIyZ2NUBZKNLjC5z3/fUlDgT6w89VsxP2qzNipOaaDyA==}
     engines: {node: '>=18'}
     cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.25.10':
+    resolution: {integrity: sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
     os: [linux]
 
   '@esbuild/linux-ppc64@0.25.5':
@@ -691,6 +775,12 @@ packages:
     cpu: [ppc64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.25.10':
+    resolution: {integrity: sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-riscv64@0.25.5':
     resolution: {integrity: sha512-kTxwu4mLyeOlsVIFPfQo+fQJAV9mh24xL+y+Bm6ej067sYANjyEw1dNHmvoqxJUCMnkBdKpvOn0Ahql6+4VyeA==}
     engines: {node: '>=18'}
@@ -701,6 +791,12 @@ packages:
     resolution: {integrity: sha512-uNIBa279Y3fkjV+2cUjx36xkx7eSjb8IvnL01eXUKXez/CBHNRw5ekCGMPM0BcmqBxBcdgUWuUXmVWwm4CH9kg==}
     engines: {node: '>=18'}
     cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.25.10':
+    resolution: {integrity: sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
     os: [linux]
 
   '@esbuild/linux-s390x@0.25.5':
@@ -715,6 +811,12 @@ packages:
     cpu: [s390x]
     os: [linux]
 
+  '@esbuild/linux-x64@0.25.10':
+    resolution: {integrity: sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/linux-x64@0.25.5':
     resolution: {integrity: sha512-uhj8N2obKTE6pSZ+aMUbqq+1nXxNjZIIjCjGLfsWvVpy7gKCOL6rsY1MhRh9zLtUtAI7vpgLMK6DxjO8Qm9lJw==}
     engines: {node: '>=18'}
@@ -727,6 +829,12 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/netbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
   '@esbuild/netbsd-arm64@0.25.5':
     resolution: {integrity: sha512-pwHtMP9viAy1oHPvgxtOv+OkduK5ugofNTVDilIzBLpoWAM16r7b/mxBvfpuQDpRQFMfuVr5aLcn4yveGvBZvw==}
     engines: {node: '>=18'}
@@ -737,6 +845,12 @@ packages:
     resolution: {integrity: sha512-9jNJl6FqaUG+COdQMjSCGW4QiMHH88xWbvZ+kRVblZsWrkXlABuGdFJ1E9L7HK+T0Yqd4akKNa/lO0+jDxQD4Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.25.10':
+    resolution: {integrity: sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [netbsd]
 
   '@esbuild/netbsd-x64@0.25.5':
@@ -751,6 +865,12 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/openbsd-arm64@0.25.10':
+    resolution: {integrity: sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
   '@esbuild/openbsd-arm64@0.25.5':
     resolution: {integrity: sha512-7A208+uQKgTxHd0G0uqZO8UjK2R0DDb4fDmERtARjSHWxqMTye4Erz4zZafx7Di9Cv+lNHYuncAkiGFySoD+Mw==}
     engines: {node: '>=18'}
@@ -761,6 +881,12 @@ packages:
     resolution: {integrity: sha512-YaFBlPGeDasft5IIM+CQAhJAqS3St3nJzDEgsgFixcfZeyGPCd6eJBWzke5piZuZ7CtL656eOSYKk4Ls2C0FRQ==}
     engines: {node: '>=18'}
     cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.25.10':
+    resolution: {integrity: sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [openbsd]
 
   '@esbuild/openbsd-x64@0.25.5':
@@ -775,11 +901,23 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openharmony-arm64@0.25.10':
+    resolution: {integrity: sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
   '@esbuild/openharmony-arm64@0.25.9':
     resolution: {integrity: sha512-4Xd0xNiMVXKh6Fa7HEJQbrpP3m3DDn43jKxMjxLLRjWnRsfxjORYJlXPO4JNcXtOyfajXorRKY9NkOpTHptErg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
+
+  '@esbuild/sunos-x64@0.25.10':
+    resolution: {integrity: sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
 
   '@esbuild/sunos-x64@0.25.5':
     resolution: {integrity: sha512-l+azKShMy7FxzY0Rj4RCt5VD/q8mG/e+mDivgspo+yL8zW7qEwctQ6YqKX34DTEleFAvCIUviCFX1SDZRSyMQA==}
@@ -793,6 +931,12 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/win32-arm64@0.25.10':
+    resolution: {integrity: sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
   '@esbuild/win32-arm64@0.25.5':
     resolution: {integrity: sha512-O2S7SNZzdcFG7eFKgvwUEZ2VG9D/sn/eIiz8XRZ1Q/DO5a3s76Xv0mdBzVM5j5R639lXQmPmSo0iRpHqUUrsxw==}
     engines: {node: '>=18'}
@@ -805,6 +949,12 @@ packages:
     cpu: [arm64]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.25.10':
+    resolution: {integrity: sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-ia32@0.25.5':
     resolution: {integrity: sha512-onOJ02pqs9h1iMJ1PQphR+VZv8qBMQ77Klcsqv9CNW2w6yLqoURLcgERAIurY6QE63bbLuqgP9ATqajFLK5AMQ==}
     engines: {node: '>=18'}
@@ -815,6 +965,12 @@ packages:
     resolution: {integrity: sha512-b33gLVU2k11nVx1OhX3C8QQP6UHQK4ZtN56oFWvVXvz2VkDoe6fbG8TOgHFxEvqeqohmRnIHe5A1+HADk4OQww==}
     engines: {node: '>=18'}
     cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.25.10':
+    resolution: {integrity: sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
     os: [win32]
 
   '@esbuild/win32-x64@0.25.5':
@@ -2208,6 +2364,15 @@ packages:
       supports-color:
         optional: true
 
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   decimal.js@10.6.0:
     resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
@@ -2411,6 +2576,11 @@ packages:
 
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
+
+  esbuild@0.25.10:
+    resolution: {integrity: sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   esbuild@0.25.5:
     resolution: {integrity: sha512-P8OtKZRv/5J5hhz0cUAdu/cLuPIKXpQl1R9pZtvmHWQvrAUVd0UNIPT4IB4W3rNOqVO0rlqHmCIbSwxh/c9yUQ==}
@@ -2688,6 +2858,10 @@ packages:
 
   fs-extra@11.3.1:
     resolution: {integrity: sha512-eXvGGwZ5CL17ZSwHWd3bbgk7UUpF6IFHtP57NYYakPvHOs8GDgDe5KJI36jIJzDkJ6eJjuzRA8eBQb6SkKue0g==}
+    engines: {node: '>=14.14'}
+
+  fs-extra@11.3.2:
+    resolution: {integrity: sha512-Xr9F6z6up6Ws+NjzMCZc6WXg2YFRlrLP9NQDO3VQrWrfiojdhS56TzueT88ze0uBdCTwEIhQ3ptnmKeWGFAe0A==}
     engines: {node: '>=14.14'}
 
   fs-extra@7.0.1:
@@ -5344,8 +5518,8 @@ snapshots:
   '@electron/windows-sign@1.2.2':
     dependencies:
       cross-dirname: 0.1.0
-      debug: 4.4.1
-      fs-extra: 11.3.1
+      debug: 4.4.3
+      fs-extra: 11.3.2
       minimist: 1.2.8
       postject: 1.0.0-alpha.6
     transitivePeerDependencies:
@@ -5372,10 +5546,16 @@ snapshots:
 
   '@emotion/unitless@0.7.5': {}
 
+  '@esbuild/aix-ppc64@0.25.10':
+    optional: true
+
   '@esbuild/aix-ppc64@0.25.5':
     optional: true
 
   '@esbuild/aix-ppc64@0.25.9':
+    optional: true
+
+  '@esbuild/android-arm64@0.25.10':
     optional: true
 
   '@esbuild/android-arm64@0.25.5':
@@ -5384,10 +5564,16 @@ snapshots:
   '@esbuild/android-arm64@0.25.9':
     optional: true
 
+  '@esbuild/android-arm@0.25.10':
+    optional: true
+
   '@esbuild/android-arm@0.25.5':
     optional: true
 
   '@esbuild/android-arm@0.25.9':
+    optional: true
+
+  '@esbuild/android-x64@0.25.10':
     optional: true
 
   '@esbuild/android-x64@0.25.5':
@@ -5396,10 +5582,16 @@ snapshots:
   '@esbuild/android-x64@0.25.9':
     optional: true
 
+  '@esbuild/darwin-arm64@0.25.10':
+    optional: true
+
   '@esbuild/darwin-arm64@0.25.5':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/darwin-x64@0.25.10':
     optional: true
 
   '@esbuild/darwin-x64@0.25.5':
@@ -5408,10 +5600,16 @@ snapshots:
   '@esbuild/darwin-x64@0.25.9':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.25.10':
+    optional: true
+
   '@esbuild/freebsd-arm64@0.25.5':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.25.10':
     optional: true
 
   '@esbuild/freebsd-x64@0.25.5':
@@ -5420,10 +5618,16 @@ snapshots:
   '@esbuild/freebsd-x64@0.25.9':
     optional: true
 
+  '@esbuild/linux-arm64@0.25.10':
+    optional: true
+
   '@esbuild/linux-arm64@0.25.5':
     optional: true
 
   '@esbuild/linux-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-arm@0.25.10':
     optional: true
 
   '@esbuild/linux-arm@0.25.5':
@@ -5432,10 +5636,16 @@ snapshots:
   '@esbuild/linux-arm@0.25.9':
     optional: true
 
+  '@esbuild/linux-ia32@0.25.10':
+    optional: true
+
   '@esbuild/linux-ia32@0.25.5':
     optional: true
 
   '@esbuild/linux-ia32@0.25.9':
+    optional: true
+
+  '@esbuild/linux-loong64@0.25.10':
     optional: true
 
   '@esbuild/linux-loong64@0.25.5':
@@ -5444,10 +5654,16 @@ snapshots:
   '@esbuild/linux-loong64@0.25.9':
     optional: true
 
+  '@esbuild/linux-mips64el@0.25.10':
+    optional: true
+
   '@esbuild/linux-mips64el@0.25.5':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.9':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.25.10':
     optional: true
 
   '@esbuild/linux-ppc64@0.25.5':
@@ -5456,10 +5672,16 @@ snapshots:
   '@esbuild/linux-ppc64@0.25.9':
     optional: true
 
+  '@esbuild/linux-riscv64@0.25.10':
+    optional: true
+
   '@esbuild/linux-riscv64@0.25.5':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.9':
+    optional: true
+
+  '@esbuild/linux-s390x@0.25.10':
     optional: true
 
   '@esbuild/linux-s390x@0.25.5':
@@ -5468,10 +5690,16 @@ snapshots:
   '@esbuild/linux-s390x@0.25.9':
     optional: true
 
+  '@esbuild/linux-x64@0.25.10':
+    optional: true
+
   '@esbuild/linux-x64@0.25.5':
     optional: true
 
   '@esbuild/linux-x64@0.25.9':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.25.10':
     optional: true
 
   '@esbuild/netbsd-arm64@0.25.5':
@@ -5480,10 +5708,16 @@ snapshots:
   '@esbuild/netbsd-arm64@0.25.9':
     optional: true
 
+  '@esbuild/netbsd-x64@0.25.10':
+    optional: true
+
   '@esbuild/netbsd-x64@0.25.5':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.9':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.25.10':
     optional: true
 
   '@esbuild/openbsd-arm64@0.25.5':
@@ -5492,13 +5726,22 @@ snapshots:
   '@esbuild/openbsd-arm64@0.25.9':
     optional: true
 
+  '@esbuild/openbsd-x64@0.25.10':
+    optional: true
+
   '@esbuild/openbsd-x64@0.25.5':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.9':
     optional: true
 
+  '@esbuild/openharmony-arm64@0.25.10':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.9':
+    optional: true
+
+  '@esbuild/sunos-x64@0.25.10':
     optional: true
 
   '@esbuild/sunos-x64@0.25.5':
@@ -5507,16 +5750,25 @@ snapshots:
   '@esbuild/sunos-x64@0.25.9':
     optional: true
 
+  '@esbuild/win32-arm64@0.25.10':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.5':
     optional: true
 
   '@esbuild/win32-arm64@0.25.9':
     optional: true
 
+  '@esbuild/win32-ia32@0.25.10':
+    optional: true
+
   '@esbuild/win32-ia32@0.25.5':
     optional: true
 
   '@esbuild/win32-ia32@0.25.9':
+    optional: true
+
+  '@esbuild/win32-x64@0.25.10':
     optional: true
 
   '@esbuild/win32-x64@0.25.5':
@@ -7076,6 +7328,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
   decimal.js@10.6.0: {}
 
   decompress-response@6.0.0:
@@ -7259,7 +7515,7 @@ snapshots:
   electron-winstaller@5.4.0:
     dependencies:
       '@electron/asar': 3.4.1
-      debug: 4.4.1
+      debug: 4.4.3
       fs-extra: 7.0.1
       lodash: 4.17.21
       temp: 0.9.4
@@ -7404,6 +7660,36 @@ snapshots:
       is-symbol: 1.1.1
 
   es6-error@4.1.1:
+    optional: true
+
+  esbuild@0.25.10:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.25.10
+      '@esbuild/android-arm': 0.25.10
+      '@esbuild/android-arm64': 0.25.10
+      '@esbuild/android-x64': 0.25.10
+      '@esbuild/darwin-arm64': 0.25.10
+      '@esbuild/darwin-x64': 0.25.10
+      '@esbuild/freebsd-arm64': 0.25.10
+      '@esbuild/freebsd-x64': 0.25.10
+      '@esbuild/linux-arm': 0.25.10
+      '@esbuild/linux-arm64': 0.25.10
+      '@esbuild/linux-ia32': 0.25.10
+      '@esbuild/linux-loong64': 0.25.10
+      '@esbuild/linux-mips64el': 0.25.10
+      '@esbuild/linux-ppc64': 0.25.10
+      '@esbuild/linux-riscv64': 0.25.10
+      '@esbuild/linux-s390x': 0.25.10
+      '@esbuild/linux-x64': 0.25.10
+      '@esbuild/netbsd-arm64': 0.25.10
+      '@esbuild/netbsd-x64': 0.25.10
+      '@esbuild/openbsd-arm64': 0.25.10
+      '@esbuild/openbsd-x64': 0.25.10
+      '@esbuild/openharmony-arm64': 0.25.10
+      '@esbuild/sunos-x64': 0.25.10
+      '@esbuild/win32-arm64': 0.25.10
+      '@esbuild/win32-ia32': 0.25.10
+      '@esbuild/win32-x64': 0.25.10
     optional: true
 
   esbuild@0.25.5:
@@ -7778,6 +8064,13 @@ snapshots:
       graceful-fs: 4.2.11
       jsonfile: 6.2.0
       universalify: 2.0.1
+
+  fs-extra@11.3.2:
+    dependencies:
+      graceful-fs: 4.2.11
+      jsonfile: 6.2.0
+      universalify: 2.0.1
+    optional: true
 
   fs-extra@7.0.1:
     dependencies:
@@ -9923,7 +10216,7 @@ snapshots:
 
   tsx@4.20.5:
     dependencies:
-      esbuild: 0.25.9
+      esbuild: 0.25.10
       get-tsconfig: 4.10.1
     optionalDependencies:
       fsevents: 2.3.3

--- a/app/src/main/crypto.ts
+++ b/app/src/main/crypto.ts
@@ -326,3 +326,7 @@ export class Crypto {
     return ""; // No filename in header
   }
 }
+
+export function encryptedFilepath(sourceID: string, itemID: string) {
+  return path.join(os.tmpdir(), "download", sourceID, itemID, "encrypted.gpg");
+}

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -130,7 +130,7 @@ export class DB {
       "SELECT uuid, version FROM items",
     );
     this.selectItemFilenameSource = this.db.prepare(
-      "SELECT filename, source_uuid FROM items WHERE source_uuid = @uuid",
+      "SELECT filename, source_uuid FROM items WHERE uuid = @uuid",
     );
     this.upsertItem = this.db.prepare(
       "INSERT INTO items (uuid, data, version) VALUES (@uuid, @data, @version) ON CONFLICT(uuid) DO UPDATE SET data=@data, version=@version",

--- a/app/src/main/database/index.ts
+++ b/app/src/main/database/index.ts
@@ -66,6 +66,10 @@ export class DB {
     [],
     { uuid: string; version: string }
   >;
+  private selectItemFilenameSource: Statement<
+    { uuid: string },
+    { filename: string; source: string }
+  >;
   private upsertItem: Statement<
     { id: string; data: string; version: string },
     void
@@ -122,6 +126,9 @@ export class DB {
 
     this.selectAllItemVersion = this.db.prepare(
       "SELECT uuid, version FROM items",
+    );
+    this.selectItemFilenameSource = this.db.prepare(
+      "SELECT filename, source_uuid FROM items WHERE uuid = @id",
     );
     this.upsertItem = this.db.prepare(
       "INSERT INTO items (uuid, data, version) VALUES (@id, @data, @version) ON CONFLICT(uuid) DO UPDATE SET data=@data, version=@version",
@@ -286,6 +293,15 @@ export class DB {
     const strIndex = JSON.stringify(index, sortKeys);
     const newVersion = computeVersion(strIndex);
     this.insertVersion.run(newVersion);
+  }
+
+  getItemFileData(itemID: string):
+    | {
+        filename: string;
+        source: string;
+      }
+    | undefined {
+    return this.selectItemFilenameSource.get({ uuid: itemID });
   }
 
   deleteItems(items: string[]) {

--- a/app/src/main/fetch/bufferedWriter.test.ts
+++ b/app/src/main/fetch/bufferedWriter.test.ts
@@ -28,16 +28,6 @@ describe("BufferedWriter constructor", () => {
     });
   });
 
-  it("should return error if stream not closed", () => {
-    const writer = new BufferedWriter();
-    writer.write("data", "utf8", () => {});
-    const result = writer.getBuffer();
-    expect(result).toBeInstanceOf(Error);
-    expect((result as Error).message).toBe(
-      "Writable stream not yet closed, cannot return buffer",
-    );
-  });
-
   it("should return concatenated buffer after stream is closed", () => {
     const writer = new BufferedWriter();
     writer.write("foo", "utf8", () => {

--- a/app/src/main/fetch/bufferedWriter.ts
+++ b/app/src/main/fetch/bufferedWriter.ts
@@ -29,10 +29,7 @@ export class BufferedWriter extends Writable {
     callback();
   }
 
-  getBuffer(): Buffer | Error {
-    if (this.final) {
-      return Buffer.concat(this.buffer);
-    }
-    return new Error("Writable stream not yet closed, cannot return buffer");
+  getBuffer(): Buffer {
+    return Buffer.concat(this.buffer);
   }
 }

--- a/app/src/main/fetch/queue.test.ts
+++ b/app/src/main/fetch/queue.test.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import fs from "fs";
+import os from "os";
+import path from "path";
+import { PassThrough } from "stream";
+
+import { TaskQueue } from "./queue";
+import { CryptoError } from "../crypto";
 import { FetchStatus, ItemMetadata } from "../../types";
 import { DB } from "../database";
 import { BufferedWriter } from "./bufferedWriter";
-import fs from "fs";
 
 // Mocks
 const mockProxyStreamRequest = vi.hoisted(() => {
@@ -18,6 +24,7 @@ vi.mock("../proxy", async () => {
 
 const mockCrypto = {
   decryptMessage: vi.fn(),
+  decryptFile: vi.fn(),
 };
 vi.mock("../crypto", () => {
   return {
@@ -37,12 +44,9 @@ vi.mock("fs", () => ({
       readFile: vi.fn(),
       unlink: vi.fn(),
     },
-    createWriteStream: vi.fn(),
+    createWriteStream: vi.fn(() => new PassThrough()),
   },
 }));
-
-import { TaskQueue } from "./queue";
-import { CryptoError } from "../crypto";
 
 // Helper to create mock DB with specific methods
 function createMockDB() {
@@ -63,6 +67,7 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockCrypto.decryptMessage.mockReset();
+    mockCrypto.decryptFile.mockReset();
   });
 
   describe("Message Processing", () => {
@@ -390,12 +395,176 @@ describe("TaskQueue - Two-Phase Download and Decryption", () => {
     });
   });
 
-  // TODO: Add tests for file download and decryption
-  // Files are downloaded directly to disk and will need separate decryption logic
-  // Test scenarios:
-  // - File downloads successfully to disk
-  // - File download fails and retries successfully
-  // - File decryption (when implemented)
+  describe("File Processing", () => {
+    it("should download and decrypt a file successfully on first attempt", async () => {
+      const db = createMockDB();
+      const metadata = { kind: "file", source: "source1" };
+
+      db.getItemWithFetchStatus = vi.fn(
+        () =>
+          [metadata, FetchStatus.Initial, 0] as [
+            ItemMetadata,
+            FetchStatus,
+            number,
+          ],
+      );
+
+      // Mock successful download
+      mockProxyStreamRequest.mockResolvedValue({
+        complete: true,
+        bytesWritten: 100,
+      });
+
+      // Mock successful decryption
+      mockCrypto.decryptFile.mockResolvedValue({
+        filePath: "/securedrop/source1",
+        filename: "plaintext.txt",
+      });
+
+      const queue = new TaskQueue(db);
+      await queue.process({ id: "msg1" }, db);
+
+      // Verify download phase
+      expect(db.setDownloadInProgress).toHaveBeenCalledWith("msg1");
+      expect(mockProxyStreamRequest).toHaveBeenCalledWith(
+        expect.objectContaining({
+          path_query: "/api/v1/sources/source1/submissions/msg1/download",
+        }),
+        expect.any(PassThrough),
+        0,
+      );
+
+      // Verify decryption phase
+      const downloadPath = path.join(
+        os.tmpdir(),
+        "download",
+        "source1",
+        "msg1",
+        "encrypted.gpg",
+      );
+      expect(db.setDecryptionInProgress).toHaveBeenCalledWith("msg1");
+      expect(mockCrypto.decryptFile).toHaveBeenCalledWith(downloadPath);
+      expect(db.completeFileItem).toHaveBeenCalledWith(
+        "msg1",
+        "/securedrop/source1/plaintext.txt",
+      );
+    });
+
+    it("should download successfully but fail decryption, and retry decryption only", async () => {
+      const db = createMockDB();
+      const metadata = { kind: "file", source: "source1" };
+
+      // First attempt: Initial status, Second attempt: FailedDecryptionRetryable
+      db.getItemWithFetchStatus = vi
+        .fn()
+        .mockReturnValueOnce([metadata, FetchStatus.Initial, 0])
+        .mockReturnValueOnce([
+          metadata,
+          FetchStatus.FailedDecryptionRetryable,
+          0,
+        ]);
+
+      // Mock successful download
+      mockProxyStreamRequest.mockResolvedValue({
+        complete: true,
+        bytesWritten: 100,
+      });
+
+      // Mock decryption failure on first attempt
+      mockCrypto.decryptFile.mockRejectedValueOnce(
+        new CryptoError("Decryption failed"),
+      );
+
+      const queue = new TaskQueue(db);
+
+      // First attempt - should fail decryption
+      await expect(queue.process({ id: "msg1" }, db)).rejects.toThrow(
+        `Decryption failed`,
+      );
+
+      // Verify download was saved to disk
+      expect(fs.promises.mkdir).toHaveBeenCalled();
+      expect(fs.createWriteStream).toHaveBeenCalledWith(
+        expect.stringContaining("/encrypted.gpg"),
+      );
+
+      expect(db.setDownloadInProgress).toHaveBeenCalledWith("msg1");
+      expect(db.setDecryptionInProgress).toHaveBeenCalledWith("msg1");
+      expect(db.failDecryption).toHaveBeenCalledWith("msg1");
+
+      // Second attempt - retry from FailedDecryptionRetryable status
+      // Mock successful decryption this time
+      mockCrypto.decryptFile.mockResolvedValue({
+        filePath: "/securedrop/source1",
+        filename: "plaintext.txt",
+      });
+
+      await queue.process({ id: "msg1" }, db);
+
+      // Should only do decryption phase (no download)
+      expect(mockProxyStreamRequest).toHaveBeenCalledTimes(1); // Only called once (first attempt)
+      expect(db.completeFileItem).toHaveBeenCalledWith(
+        "msg1",
+        "/securedrop/source1/plaintext.txt",
+      );
+
+      // Should clean up the file after successful decryption
+      expect(fs.promises.unlink).toHaveBeenCalledWith(
+        expect.stringContaining("/encrypted.gpg"),
+      );
+    });
+
+    it("should fail download, retry download and decryption successfully", async () => {
+      const db = createMockDB();
+      const metadata = { kind: "file", source: "source1" };
+
+      // First attempt: Initial status, Second attempt: FailedDownloadRetryable
+      db.getItemWithFetchStatus = vi
+        .fn()
+        .mockReturnValueOnce([metadata, FetchStatus.Initial, 0])
+        .mockReturnValueOnce([
+          metadata,
+          FetchStatus.FailedDownloadRetryable,
+          50,
+        ]);
+
+      const queue = new TaskQueue(db);
+
+      // First attempt - download fails
+      mockProxyStreamRequest.mockResolvedValueOnce({
+        complete: false,
+        bytesWritten: 50,
+        error: new Error("Network error"),
+      });
+
+      await expect(queue.process({ id: "msg1" }, db)).rejects.toThrow(
+        "Unable to complete stream download",
+      );
+
+      expect(db.setDownloadInProgress).toHaveBeenCalledWith("msg1");
+      expect(db.setDownloadInProgress).toHaveBeenCalledWith("msg1", 50); // Progress update
+      expect(db.failDownload).toHaveBeenCalledWith("msg1");
+
+      // Second attempt - download and decrypt successfully
+      mockProxyStreamRequest.mockResolvedValueOnce({
+        complete: true,
+        bytesWritten: 100,
+      });
+
+      mockCrypto.decryptFile.mockResolvedValue({
+        filePath: "/securedrop/source1",
+        filename: "plaintext.txt",
+      });
+
+      await queue.process({ id: "msg1" }, db);
+
+      expect(mockProxyStreamRequest).toHaveBeenCalledTimes(2);
+      expect(db.completeFileItem).toHaveBeenCalledWith(
+        "msg1",
+        "/securedrop/source1/plaintext.txt",
+      );
+    });
+  });
 
   describe("Edge Cases and Error Handling", () => {
     it("should skip items that are already complete", async () => {

--- a/app/src/main/fetch/queue.test.ts
+++ b/app/src/main/fetch/queue.test.ts
@@ -26,8 +26,10 @@ const mockCrypto = {
   decryptMessage: vi.fn(),
   decryptFile: vi.fn(),
 };
-vi.mock("../crypto", () => {
+vi.mock("../crypto", async () => {
+  const actual = await vi.importActual("../crypto");
   return {
+    ...actual,
     Crypto: {
       getInstance: () => mockCrypto,
     },

--- a/app/src/main/fetch/queue.ts
+++ b/app/src/main/fetch/queue.ts
@@ -193,7 +193,7 @@ export class TaskQueue {
   ) {
     const crypto = Crypto.getInstance();
     if (!crypto) {
-      throw new Error("Crypto not initilaized in fetch worker, cannot decrypt");
+      throw new Error("Crypto not initialized in fetch worker, cannot decrypt");
     }
 
     // Set status to decryption in progress

--- a/app/src/main/sync.test.ts
+++ b/app/src/main/sync.test.ts
@@ -10,14 +10,26 @@ import type {
   JournalistMetadata,
 } from "../../src/types";
 import * as proxyModule from "../../src/main/proxy";
+import { encryptedFilepath } from "./crypto";
+import fs from "fs";
 
-function mockDB({ index = { sources: {}, items: {}, journalists: {} } } = {}) {
+vi.mock("fs", () => ({
+  default: {
+    rmSync: vi.fn(),
+  },
+}));
+
+function mockDB({
+  index = { sources: {}, items: {}, journalists: {} },
+  itemFileData = {},
+} = {}) {
   return {
     getVersion: vi.fn(() => "v1"),
     getIndex: vi.fn(() => index),
     deleteItems: vi.fn((_itemIDs) => {}),
     deleteSources: vi.fn((_sourceIDs) => {}),
     updateMetadata: vi.fn((_metadata) => {}),
+    getItemFileData: vi.fn(() => itemFileData),
   } as unknown as DB;
 }
 
@@ -270,6 +282,10 @@ describe("syncMetadata", () => {
 
     db = mockDB({
       index: clientIndex,
+      itemFileData: {
+        filename: "/securedrop/plaintext.txt",
+        source: "source1",
+      },
     });
 
     const proxyMock = mockProxyResponses([
@@ -292,6 +308,14 @@ describe("syncMetadata", () => {
     expect(proxyMock).toHaveBeenCalledTimes(2);
     expect(db.deleteItems).toHaveBeenCalledWith(["item2"]);
     expect(db.updateMetadata).toHaveBeenCalledWith(metadata);
+    expect(fs.rmSync).toHaveBeenCalledWith("/securedrop/plaintext.txt", {
+      force: true,
+      recursive: true,
+    });
+    expect(fs.rmSync).toHaveBeenCalledWith(
+      encryptedFilepath("source1", "item2"),
+      { force: true, recursive: true },
+    );
   });
 
   it("reconciles partial sources", async () => {

--- a/app/src/main/sync.test.ts
+++ b/app/src/main/sync.test.ts
@@ -284,7 +284,7 @@ describe("syncMetadata", () => {
       index: clientIndex,
       itemFileData: {
         filename: "/securedrop/plaintext.txt",
-        source: "source1",
+        source_uuid: "source1",
       },
     });
 
@@ -308,13 +308,13 @@ describe("syncMetadata", () => {
     expect(proxyMock).toHaveBeenCalledTimes(2);
     expect(db.deleteItems).toHaveBeenCalledWith(["item2"]);
     expect(db.updateMetadata).toHaveBeenCalledWith(metadata);
+    expect(fs.rmSync).toHaveBeenCalledTimes(2);
     expect(fs.rmSync).toHaveBeenCalledWith("/securedrop/plaintext.txt", {
       force: true,
-      recursive: true,
     });
     expect(fs.rmSync).toHaveBeenCalledWith(
       encryptedFilepath("source1", "item2"),
-      { force: true, recursive: true },
+      { force: true },
     );
   });
 

--- a/app/src/main/sync.ts
+++ b/app/src/main/sync.ts
@@ -152,13 +152,12 @@ function deleteItems(db: DB, itemIDs: string[]) {
       continue;
     }
     if (data.filename) {
-      fs.rmSync(data.filename, { recursive: true, force: true });
+      fs.rmSync(data.filename, { force: true });
     }
     // Encrypted file should already have been removed on decryption,
     // but attempt again to clean up here just in case.
-    if (data.source) {
-      fs.rmSync(encryptedFilepath(data.source, itemID), {
-        recursive: true,
+    if (data.source_uuid) {
+      fs.rmSync(encryptedFilepath(data.source_uuid, itemID), {
         force: true,
       });
     }


### PR DESCRIPTION
> [!NOTE]
> This is a copy of freedomofpress/securedrop-client#2716 for testing GitHub Copilot.

Fixes #2712 

When deleting `items` as part of metadata sync, also delete the unencrypted file (if it exists) from the filesystem and attempt to cleanup remaining encrypted files.

## Test plan
<!-- Delete this section if not applicable (e.g., some docs-only changes) -->

## Checklist

<!-- If you leave any box below unchecked, please clarify where you may need support.
     If you're unsure, that's fine — a reviewer can help you out. -->

This change accounts for:
- [ ] testing changes on Qubes as needed (especially changes related to cryptography, export, disposable VM use, or complex UI changes)
- [ ] any needed updates to the [AppArmor profile] for files beyond the application code
- [ ] any needed [self-contained] database migrations (including testing against a clean test database from `main`)

[AppArmor profile]: https://github.com/freedomofpress/securedrop-client/blob/main/client/files/usr.bin.securedrop-client
[self-contained]: https://github.com/freedomofpress/securedrop-client/tree/main/client#generating-and-running-database-migrations
